### PR TITLE
Simplify permissions setting in docker-entrypoint script

### DIFF
--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -24,9 +24,9 @@ main()
 	find "${FOT_API_DIR}" "${FOT_API_DATA_DIR}" -type d -not -path "*/modules/*" -exec chmod 770 {} + || exit 2
 	find "${FOT_API_DIR}" "${FOT_API_DATA_DIR}" -type f -not -path "*/modules/*" -exec chmod 660 {} + || exit 2
 	find "${FOT_API_DIR}" "${FOT_API_DATA_DIR}" -type d -not -path "*/modules/*" -exec chmod ug+s {} + || exit 2
-	find "${FOT_API_LOGS_DIR}" "${FOT_API_TMP_DIR}" -type d -not -path "*/modules/*" -exec chmod 775 {} + || exit 2
-	find "${FOT_API_LOGS_DIR}" "${FOT_API_TMP_DIR}" -type f -not -path "*/modules/*" -exec chmod 664 {} + || exit 2
-	find "${FOT_API_LOGS_DIR}" "${FOT_API_TMP_DIR}" -type d -not -path "*/modules/*" -exec chmod +s {} + || exit 2
+	find "${FOT_API_LOGS_DIR}" "${FOT_API_TMP_DIR}" -type d -exec chmod 775 {} + || exit 2
+	find "${FOT_API_LOGS_DIR}" "${FOT_API_TMP_DIR}" -type f -exec chmod 664 {} + || exit 2
+	find "${FOT_API_LOGS_DIR}" "${FOT_API_TMP_DIR}" -type d -exec chmod +s {} + || exit 2
 	chmod ug+x "${FOT_API_DIR}/main.py" || exit 2
 	# echo "${USER} ALL=(ALL) ALL" | sudo tee -a "/etc/sudoers.d/${USER}" > /dev/null || exit 2
 	echo ""


### PR DESCRIPTION
Streamline the permissions setting process in the docker-entrypoint script by removing unnecessary path exclusions for log and temporary directories.